### PR TITLE
Bump `ghostwriter/container` from `4.0.4` to `4.0.5`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/clock": "^3.0.1",
         "ghostwriter/collection": "^2.0.0",
         "ghostwriter/config": "^1.0.0",
-        "ghostwriter/container": "^4.0.4",
+        "ghostwriter/container": "^4.0.5",
         "ghostwriter/event-dispatcher": "^5.0.2",
         "ghostwriter/filesystem": "^0.1.1",
         "ghostwriter/json": "^3.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d23eef8cad9973bb77e01462839cdb44",
+    "content-hash": "aaf56a9ea49cada538c47c39c0421fa5",
     "packages": [
         {
             "name": "composer/semver",
@@ -339,16 +339,16 @@
         },
         {
             "name": "ghostwriter/container",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/container.git",
-                "reference": "2fcb892e45f0410709ae0c0ddd4b5c54ddadd889"
+                "reference": "a0aa3c884e1b8e4bb1b044c72ebac74675a45bf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/container/zipball/2fcb892e45f0410709ae0c0ddd4b5c54ddadd889",
-                "reference": "2fcb892e45f0410709ae0c0ddd4b5c54ddadd889",
+                "url": "https://api.github.com/repos/ghostwriter/container/zipball/a0aa3c884e1b8e4bb1b044c72ebac74675a45bf6",
+                "reference": "a0aa3c884e1b8e4bb1b044c72ebac74675a45bf6",
                 "shasum": ""
             },
             "require": {
@@ -395,7 +395,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-01T21:19:38+00:00"
+            "time": "2025-02-02T00:23:20+00:00"
         },
         {
             "name": "ghostwriter/event-dispatcher",


### PR DESCRIPTION
Bumps `ghostwriter/container` from `4.0.4` to `4.0.5`.

- Update `composer.json`
- Update `composer.lock`