### PR TITLE
Bump `ghostwriter/case-converter` from `1.0.0` to `2.0.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "composer-plugin-api": "^2.6.0",
         "composer-runtime-api": "^2.2.2",
         "composer/semver": "^3.4.3",
-        "ghostwriter/case-converter": "^1.0.0",
+        "ghostwriter/case-converter": "^2.0.0",
         "ghostwriter/clock": "^3.0.1",
         "ghostwriter/collection": "^2.0.0",
         "ghostwriter/config": "^1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aaf56a9ea49cada538c47c39c0421fa5",
+    "content-hash": "c7dde71ff5df8d0c0589a8a52d5df8ed",
     "packages": [
         {
             "name": "composer/semver",
@@ -89,25 +89,24 @@
         },
         {
             "name": "ghostwriter/case-converter",
-            "version": "1.0.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/case-converter.git",
-                "reference": "69a981f3532d86313e5b5a4b37ca1d64659a0caa"
+                "reference": "e3479766f945d78c3e6a64569d8293cf6fe7b80e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/case-converter/zipball/69a981f3532d86313e5b5a4b37ca1d64659a0caa",
-                "reference": "69a981f3532d86313e5b5a4b37ca1d64659a0caa",
+                "url": "https://api.github.com/repos/ghostwriter/case-converter/zipball/e3479766f945d78c3e6a64569d8293cf6fe7b80e",
+                "reference": "e3479766f945d78c3e6a64569d8293cf6fe7b80e",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": "^8.3"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/psalm-plugin": "^0.2 || ^0.3 || ^1.0"
+                "ghostwriter/coding-standard": "dev-main"
             },
             "type": "library",
             "autoload": {
@@ -127,7 +126,7 @@
                     "role": "Developer"
                 }
             ],
-            "description": "Convert strings from and to Ada, Camel, Cobol, Kebab, Lower, Macro, Pascal, Sentence, Snake, Title, Train, and Upper cases",
+            "description": "Convert strings from and to AdaCase, CamelCase, CobolCase, KebabCase, Lowercase, MacroCase, PascalCase, SentenceCase, SnakeCase, TitleCase, TrainCase, and Uppercase",
             "homepage": "https://github.com/ghostwriter/case-converter",
             "keywords": [
                 "ada-case",
@@ -146,10 +145,9 @@
                 "upper-case"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/case-converter",
-                "forum": "https://github.com/ghostwriter/case-converter/discussions",
                 "issues": "https://github.com/ghostwriter/case-converter/issues",
                 "rss": "https://github.com/ghostwriter/case-converter/releases.atom",
+                "security": "https://github.com/ghostwriter/case-converter/security/advisories/new",
                 "source": "https://github.com/ghostwriter/case-converter"
             },
             "funding": [
@@ -158,7 +156,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-10T19:54:53+00:00"
+            "time": "2025-02-06T12:07:45+00:00"
         },
         {
             "name": "ghostwriter/clock",


### PR DESCRIPTION
Bumps `ghostwriter/case-converter` from `1.0.0` to `2.0.0`.

- Update `composer.json`
- Update `composer.lock`