### PR TITLE
Update symfony/console to version 7.3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "ghostwriter/json": "^3.0.0",
         "ghostwriter/shell": "^0.1.0",
         "ghostwriter/uuid": "^1.0.3",
-        "symfony/console": "^7.3.4"
+        "symfony/console": "^7.3.5"
     },
     "require-dev": {
         "ext-xdebug": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4113a03d62d92cae8631af598e518453",
+    "content-hash": "cfe279417362640d780024874ba54a95",
     "packages": [
         {
             "name": "composer/semver",
@@ -750,16 +750,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.4",
+            "version": "v7.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db"
+                "reference": "cdb80fa5869653c83cfe1a9084a673b6daf57ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
-                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cdb80fa5869653c83cfe1a9084a673b6daf57ea7",
+                "reference": "cdb80fa5869653c83cfe1a9084a673b6daf57ea7",
                 "shasum": ""
             },
             "require": {
@@ -824,7 +824,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.4"
+                "source": "https://github.com/symfony/console/tree/v7.3.5"
             },
             "funding": [
                 {
@@ -844,7 +844,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-22T15:31:00+00:00"
+            "time": "2025-10-14T15:46:26+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",


### PR DESCRIPTION
Updates the `symfony/console` dependency from `v7.3.4` to `7.3.5`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`