### PR TITLE
Update ghostwriter/filesystem to version 0.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "ghostwriter/config": "^2.0.1",
         "ghostwriter/container": "^6.0.1",
         "ghostwriter/event-dispatcher": "^6.0.0",
-        "ghostwriter/filesystem": "^0.1.1",
+        "ghostwriter/filesystem": "^0.1.2",
         "ghostwriter/json": "^3.0.0",
         "ghostwriter/shell": "^0.1.0",
         "ghostwriter/uuid": "^1.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc7172b0f07762c9e34d5caddf70c1fd",
+    "content-hash": "cc49d359223d08ad3dc3bd675a709450",
     "packages": [
         {
             "name": "composer/semver",
@@ -496,25 +496,37 @@
         },
         {
             "name": "ghostwriter/filesystem",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/filesystem.git",
-                "reference": "48779b1db050cdeb3c1d9ff9752f75acd1318398"
+                "reference": "49caa2d2adfdf01afb5db347355bf3fb5efde704"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/filesystem/zipball/48779b1db050cdeb3c1d9ff9752f75acd1318398",
-                "reference": "48779b1db050cdeb3c1d9ff9752f75acd1318398",
+                "url": "https://api.github.com/repos/ghostwriter/filesystem/zipball/49caa2d2adfdf01afb5db347355bf3fb5efde704",
+                "reference": "49caa2d2adfdf01afb5db347355bf3fb5efde704",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.3"
+                "php": "~8.4.0 || ~8.5.0"
             },
             "require-dev": {
-                "ghostwriter/coding-standard": "dev-main"
+                "ext-xdebug": "*",
+                "ghostwriter/coding-standard": "dev-main",
+                "ghostwriter/container": "^6.0.1",
+                "mockery/mockery": "^1.6.12",
+                "phpunit/phpunit": "^12.4.3",
+                "symfony/var-dumper": "^7.3.5"
             },
             "type": "library",
+            "extra": {
+                "ghostwriter": {
+                    "container": {
+                        "definition": "Ghostwriter\\Filesystem\\Container\\FilesystemDefinition"
+                    }
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Ghostwriter\\Filesystem\\": "src"
@@ -522,7 +534,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "BSD-4-Clause"
             ],
             "authors": [
                 {
@@ -539,8 +551,6 @@
                 "ghostwriter"
             ],
             "support": {
-                "docs": "https://github.com/ghostwriter/filesystem",
-                "forum": "https://github.com/ghostwriter/filesystem/discussions",
                 "issues": "https://github.com/ghostwriter/filesystem/issues",
                 "rss": "https://github.com/ghostwriter/filesystem/releases.atom",
                 "security": "https://github.com/ghostwriter/filesystem/security/advisories/new",
@@ -552,7 +562,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-10T16:28:42+00:00"
+            "time": "2025-11-21T06:25:48+00:00"
         },
         {
             "name": "ghostwriter/json",


### PR DESCRIPTION
Updates the `ghostwriter/filesystem` dependency from `0.1.1` to `0.1.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`