### PR TITLE
Update ghostwriter/event-dispatcher to version 6.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "ghostwriter/collection": "^2.0.0",
         "ghostwriter/config": "^2.0.1",
         "ghostwriter/container": "^6.0.1",
-        "ghostwriter/event-dispatcher": "^6.0.0",
+        "ghostwriter/event-dispatcher": "^6.0.1",
         "ghostwriter/filesystem": "^0.1.2",
         "ghostwriter/json": "^3.0.0",
         "ghostwriter/shell": "^0.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7090417693275d9b6481a5cd0e3ae5a4",
+    "content-hash": "61d9dc85b0d1189e86b7dda0496a5992",
     "packages": [
         {
             "name": "composer/semver",
@@ -419,16 +419,16 @@
         },
         {
             "name": "ghostwriter/event-dispatcher",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/event-dispatcher.git",
-                "reference": "532d7082595fddb2532368b74bd64a275634dd58"
+                "reference": "3eeba274f9f4be110f028ffca3e14ace4c69b8ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/event-dispatcher/zipball/532d7082595fddb2532368b74bd64a275634dd58",
-                "reference": "532d7082595fddb2532368b74bd64a275634dd58",
+                "url": "https://api.github.com/repos/ghostwriter/event-dispatcher/zipball/3eeba274f9f4be110f028ffca3e14ace4c69b8ce",
+                "reference": "3eeba274f9f4be110f028ffca3e14ace4c69b8ce",
                 "shasum": ""
             },
             "require": {
@@ -443,7 +443,7 @@
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^12.4.3",
+                "phpunit/phpunit": "^12.4.4",
                 "symfony/var-dumper": "^7.3.5"
             },
             "type": "library",
@@ -492,7 +492,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-18T06:07:45+00:00"
+            "time": "2025-11-23T02:58:39+00:00"
         },
         {
             "name": "ghostwriter/filesystem",


### PR DESCRIPTION
Updates the `ghostwriter/event-dispatcher` dependency from `6.0.0` to `6.0.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`