### PR TITLE
Update ghostwriter/coding-standard to version dev-main#d0b2d2d

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2182,12 +2182,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "76bcbf37368132f07904b57959d1c896ae089297"
+                "reference": "d0b2d2d508f8afb6974f640eab8e1b118c76c956"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/76bcbf37368132f07904b57959d1c896ae089297",
-                "reference": "76bcbf37368132f07904b57959d1c896ae089297",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/d0b2d2d508f8afb6974f640eab8e1b118c76c956",
+                "reference": "d0b2d2d508f8afb6974f640eab8e1b118c76c956",
                 "shasum": ""
             },
             "require": {
@@ -2363,7 +2363,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-06T14:14:36+00:00"
+            "time": "2025-12-06T17:05:14+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#76bcbf3` to `dev-main#d0b2d2d`.

This pull request changes the following file(s): 

- Update `composer.lock`