### PR TITLE
Update ghostwriter/coding-standard to version dev-main#e27330d

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2186,12 +2186,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "459d0b70d8b229bb3ba104fc7bc1635b5da7deae"
+                "reference": "e27330dbc89488036ed430dd164573ab3f9685ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/459d0b70d8b229bb3ba104fc7bc1635b5da7deae",
-                "reference": "459d0b70d8b229bb3ba104fc7bc1635b5da7deae",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/e27330dbc89488036ed430dd164573ab3f9685ce",
+                "reference": "e27330dbc89488036ed430dd164573ab3f9685ce",
                 "shasum": ""
             },
             "require": {
@@ -2250,7 +2250,7 @@
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.7.0",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^12.5.6",
+                "phpunit/phpunit": "^12.5.7",
                 "symfony/process": "^8.0.3",
                 "symfony/var-dumper": "^8.0.3"
             },
@@ -2366,7 +2366,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-23T18:48:59+00:00"
+            "time": "2026-01-24T16:27:30+00:00"
         },
         {
             "name": "ghostwriter/github-cli",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#459d0b7` to `dev-main#e27330d`.

This pull request changes the following file(s): 

- Update `composer.lock`