### PR TITLE
Update docker/build-push-action to version v7

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -73,7 +73,7 @@ jobs:
           echo "Platforms: ${{ steps.buildx.outputs.platforms }}"
 
       - name: Build and Push ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           cache-from: type=gha,scope=${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}
           cache-to: type=gha,scope=${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }},mode=max


### PR DESCRIPTION
Updates the `docker/build-push-action` GitHub Action to version `v7`.

This pull request changes the following file(s): 

- Update `pliance/.github/workflows/docker-build-push.yml`