### PR TITLE
Update docker/metadata-action to version v6

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.DOCKER_IMAGE }}
           labels: |


### PR DESCRIPTION
Updates the `docker/metadata-action` GitHub Action to version `v6`.

This pull request changes the following file(s): 

- Update `pliance/.github/workflows/docker-build-push.yml`