### PR TITLE
Update boundwize/structarmed to version 0.8.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.8.2",
+        "boundwize/structarmed": "^0.8.6",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/phpunit-assertions": "^0.1.0",
         "ghostwriter/testify": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d2c1dbe268af724f7193620c58d0825",
+    "content-hash": "1505fbc2993b9617dde1253281057ad6",
     "packages": [
         {
             "name": "composer/semver",
@@ -1756,16 +1756,16 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.8.2",
+            "version": "0.8.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "68e32d9eb00d80b8a6a4a21a6a3f350ff8c59747"
+                "reference": "6db298b5bd6185f61cc6df50e98a9ce64ed2828f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/68e32d9eb00d80b8a6a4a21a6a3f350ff8c59747",
-                "reference": "68e32d9eb00d80b8a6a4a21a6a3f350ff8c59747",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/6db298b5bd6185f61cc6df50e98a9ce64ed2828f",
+                "reference": "6db298b5bd6185f61cc6df50e98a9ce64ed2828f",
                 "shasum": ""
             },
             "require": {
@@ -1818,7 +1818,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.8.2"
+                "source": "https://github.com/boundwize/structarmed/tree/0.8.6"
             },
             "funding": [
                 {
@@ -1826,7 +1826,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-28T23:25:35+00:00"
+            "time": "2026-05-29T01:54:57+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.8.2` to `0.8.6`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`